### PR TITLE
0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cendat"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
   { name="G. Lance Couzens", email="lance.couzens@gmail.com" },
 ]


### PR DESCRIPTION
patch bug where aggregate requests including within clauses with full hierarchy down to the set_geo sumlev returned all target geographies in the parent branch (i.e., the final level was being discarded).

with this change, full spec within clauses are added to the task list and parent geography extrapolation and fetching is bypassed.

new unit test for validation.